### PR TITLE
Updated the video tags to have variable height

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -35,13 +35,13 @@ const Hero = () => {
         } else {
             setWindowWidth(() => window.innerWidth);
         }
-    });
+    }, []);
     return (
         <div className="flex flex-col justify-center items-center w-full h-screen overflow-hidden">
             <video
                 className={`${
                     introPlayed ? "opacity-0" : ""
-                } z-[1] hero_intro_vid absolute w-screen h-screen object-cover duration-150 ease-in-out`}
+                } z-[1] hero_intro_vid absolute object-cover w-full duration-150 ease-in-out`}
                 src={
                     windowWidth >= 768
                         ? "videos/intro.mp4"
@@ -49,17 +49,19 @@ const Hero = () => {
                 }
                 muted
                 autoPlay
+                playsInline
                 onEnded={() => setIntroPlayed((state) => true)}
             />
             <video
                 ref={loopRef}
-                className="md:scale-[70%] scale-[90%]  absolute w-screen h-screen object-cover"
+                className="md:scale-[70%] scale-[90%] absolute object-cover w-full"
                 src={
                     windowWidth >= 768
                         ? "videos/loop.mp4"
                         : "videos/loop-portrait.mp4"
                 }
                 muted
+                playsInline
                 loop
             />
             <div className="hero_intro_text absolute z-10 flex flex-col gap-4 justify-center items-center">


### PR DESCRIPTION
Width has been set to window width, but height is variable. This prevents clipping on the edges of the video. 

This does introduce vertical clipping when the aspect ratio of the window is not the same as the video's aspect ratio. But, overall, the experience is much better with this fix 